### PR TITLE
Remove sudo for chip-tool commands

### DIFF
--- a/how-to/chip-tool-commission-and-control.rst
+++ b/how-to/chip-tool-commission-and-control.rst
@@ -74,7 +74,7 @@ Commission
 
       .. code:: shell
 
-         sudo chip-tool pairing onnetwork 110 20202021
+         chip-tool pairing onnetwork 110 20202021
 
       where:
 
@@ -117,7 +117,7 @@ Commission
 
       .. code:: shell
 
-         sudo chip-tool pairing ble-thread 110 hex:0e08...f7f8 20202021 3840
+         chip-tool pairing ble-thread 110 hex:0e08...f7f8 20202021 3840
 
       where:
 
@@ -135,7 +135,7 @@ Toggle:
 
 .. code:: shell
 
-   sudo chip-tool onoff toggle 110 1
+   chip-tool onoff toggle 110 1
 
 where:
 

--- a/how-to/matter-and-thread-on-ubuntu.md
+++ b/how-to/matter-and-thread-on-ubuntu.md
@@ -132,7 +132,7 @@ sudo openthread-border-router.ot-ctl dataset active -x
 
 Now, pair the Thread device over BLE:
 ```bash
-sudo chip-tool pairing ble-thread 110 hex:<active-dataset> 20202021 3840
+chip-tool pairing ble-thread 110 hex:<active-dataset> 20202021 3840
 ```
 where:
 - `110` is the assigned node ID for the app.
@@ -149,13 +149,13 @@ If it didn't work, it may be because it has taken too long to reach this step an
 
 There are a few ways to control the device. The `toggle` command is stateless and the simplest:
 ```bash
-sudo chip-tool onoff toggle 110 1
+chip-tool onoff toggle 110 1
 ```
 
 To turn on and off:
 ```bash
-sudo chip-tool onoff on 110 1
-sudo chip-tool onoff off 110 1
+chip-tool onoff on 110 1
+chip-tool onoff off 110 1
 ```
 
 

--- a/tutorial/pi-gpio-commander.md
+++ b/tutorial/pi-gpio-commander.md
@@ -180,7 +180,7 @@ sudo snap connect chip-tool:avahi-observe
 
 We are ready to pair:
 ```bash
-sudo chip-tool pairing onnetwork 110 20202021
+chip-tool pairing onnetwork 110 20202021
 ```
 where:
 - `110` is the node id being assigned to this device
@@ -207,7 +207,7 @@ the corresponding Debian packages / Snaps need to be installed in advance.
 
 Now, pair the Thread device over Bluetooth LE
 ```bash
-sudo chip-tool pairing ble-thread 110 hex:<active-dataset> 20202021 3840
+chip-tool pairing ble-thread 110 hex:<active-dataset> 20202021 3840
 ```
 where:
 - `110` is the assigned node ID for the app.
@@ -226,7 +226,7 @@ If this doesn't work, it may be because it has taken too long to reach this step
 ## Control
 There are a few ways to control the device. The `toggle` command is stateless and simplest. 
 ```
-sudo chip-tool onoff toggle 110 1
+chip-tool onoff toggle 110 1
 ```
 
 <!-- links -->


### PR DESCRIPTION
Chip Tool snap has changed and now works without root privileges:
https://github.com/canonical/chip-tool-snap/pull/55

Closes #25 
Depends on release Chip Tool snap v1.3.0.0+snap to latest/stable.