### PR TITLE
Update link to official Chip Tool docs

### DIFF
--- a/how-to/chip-tool-commission-and-control.rst
+++ b/how-to/chip-tool-commission-and-control.rst
@@ -146,10 +146,10 @@ where:
 More reading
 ------------
 
-This documentation covered only some of common scenarios for commissioning and
-controlling Matter devices via Chip Tool. 
+This documentation covered only some of the common scenarios for commissioning and
+controlling Matter devices via Chip Tool.
 The project provides a
-`guide <https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/chip_tool_guide.md#using-chip-tool-for-matter-device-testing>`__
-with various usage examples. 
+`guide <https://project-chip.github.io/connectedhomeip-doc/guides/chip_tool_guide.html#using-chip-tool-for-matter-device-testing>`__
+with various usage examples.
 
 However, for a complete list of sub-commands and options, it is best to use the tool's usage instructions using the terminal.


### PR DESCRIPTION
Old link pointed to source code of official documentation. New link points to rendered docs.